### PR TITLE
Recognise Pluscom dialup modem (Conexant 93010)

### DIFF
--- a/app/src/main/java/de/kai_morich/simple_usb_terminal/CustomProber.java
+++ b/app/src/main/java/de/kai_morich/simple_usb_terminal/CustomProber.java
@@ -15,6 +15,7 @@ class CustomProber {
     static UsbSerialProber getCustomProber() {
         ProbeTable customTable = new ProbeTable();
         customTable.addProduct(0x16d0, 0x087e, CdcAcmSerialDriver.class); // e.g. Digispark CDC
+        customTable.addProduct(0x0572, 0x1329, CdcAcmSerialDriver.class); // Conexant 93010
         return new UsbSerialProber(customTable);
     }
 


### PR DESCRIPTION
This PR adds support for the Pluscom 56K V.92 USB2.0 Fax Modem, which uses the Conexant 93010 chipset.