### PR TITLE
terminal: Allow connecting with driver not supporting status and control

### DIFF
--- a/app/src/main/java/de/kai_morich/simple_usb_terminal/SerialSocket.java
+++ b/app/src/main/java/de/kai_morich/simple_usb_terminal/SerialSocket.java
@@ -6,6 +6,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.hardware.usb.UsbDeviceConnection;
+import android.util.Log;
 
 import com.hoho.android.usbserial.driver.UsbSerialPort;
 import com.hoho.android.usbserial.util.SerialInputOutputManager;
@@ -16,6 +17,7 @@ import java.security.InvalidParameterException;
 public class SerialSocket implements SerialInputOutputManager.Listener {
 
     private static final int WRITE_WAIT_MILLIS = 2000; // 0 blocked infinitely on unprogrammed arduino
+    private final static String TAG = SerialSocket.class.getSimpleName();
 
     private final BroadcastReceiver disconnectBroadcastReceiver;
 
@@ -46,8 +48,12 @@ public class SerialSocket implements SerialInputOutputManager.Listener {
     void connect(SerialListener listener) throws IOException {
         this.listener = listener;
         context.registerReceiver(disconnectBroadcastReceiver, new IntentFilter(Constants.INTENT_ACTION_DISCONNECT));
-        serialPort.setDTR(true); // for arduino, ...
-        serialPort.setRTS(true);
+	try {
+	    serialPort.setDTR(true); // for arduino, ...
+	    serialPort.setRTS(true);
+	} catch (UnsupportedOperationException e) {
+	    Log.d(TAG, "Failed to set initial DTR/RTS", e);
+	}
         ioManager = new SerialInputOutputManager(serialPort, this);
         ioManager.start();
     }

--- a/app/src/main/java/de/kai_morich/simple_usb_terminal/TerminalFragment.java
+++ b/app/src/main/java/de/kai_morich/simple_usb_terminal/TerminalFragment.java
@@ -290,7 +290,11 @@ public class TerminalFragment extends Fragment implements ServiceConnection, Ser
         connected = Connected.Pending;
         try {
             usbSerialPort.open(usbConnection);
-            usbSerialPort.setParameters(baudRate, UsbSerialPort.DATABITS_8, UsbSerialPort.STOPBITS_1, UsbSerialPort.PARITY_NONE);
+            try {
+                usbSerialPort.setParameters(baudRate, UsbSerialPort.DATABITS_8, UsbSerialPort.STOPBITS_1, UsbSerialPort.PARITY_NONE);
+            } catch (UnsupportedOperationException e) {
+                status("Setting serial parameters failed: " + e.getMessage());
+            }
             SerialSocket socket = new SerialSocket(getActivity().getApplicationContext(), usbConnection, usbSerialPort);
             service.connect(socket);
             // usb connect is not asynchronous. connect-success and connect-error are returned immediately from socket.connect


### PR DESCRIPTION
Currently if the driver doesn't support either status or control the connecting will fail with UnsupportedOperationException. Allow connection to continue even if those optional operations fail